### PR TITLE
Alarm back-end CRUD functions

### DIFF
--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
@@ -2,6 +2,9 @@ package com.ruinyourlifealarm.ruinyourlifealarm.business;
 
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Alarm;
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.DatabaseHandler;
+//import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Message;
+
+import java.util.Calendar;
 
 /**
  * Created by tiffanyjiang on 2017-12-02.
@@ -14,11 +17,20 @@ public class AccessAlarms {
         this.database = database;
     }
 
-    public void createAlarm() {
+//    public void createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
+//
+//    }
+//
+//    public void createAlarm(String customMessage, String recipientPhoneNumber, Time alarmTime) {
+//        int msgId = (int)(database.createMessage(customMessage));
+//        createAlarm(msgId, recipientPhoneNumber, alarmTime);
+//    }
+
+    public void createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime) {
         //TODO
     }
 
-    public Alarm getAlarm() {
+    public Alarm getAlarm(int id) {
         //TODO
         return null;
     }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
@@ -26,12 +26,11 @@ public class AccessAlarms {
 //        createAlarm(msgId, recipientPhoneNumber, alarmTime);
 //    }
 
-    public void createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
-        //TODO
+    public int createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
+        return ((int)database.createAlarm(message, recipientPhoneNumber, alarmTime, alarmIsOn));
     }
 
     public Alarm getAlarm(int id) {
-        //TODO
-        return null;
+        return database.getAlarm(id);
     }
 }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
@@ -18,19 +18,24 @@ public class AccessAlarms {
     }
 
 //    public void createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
-//
+//        database.createAlarm(messageId, recipientPhoneNumber, alarmTime);
 //    }
 //
 //    public void createAlarm(String customMessage, String recipientPhoneNumber, Time alarmTime) {
-//        int msgId = (int)(database.createMessage(customMessage));
-//        createAlarm(msgId, recipientPhoneNumber, alarmTime);
+//        int messageId = (int)(database.createMessage(customMessage));
+//        createAlarm(messageId, recipientPhoneNumber, alarmTime);
 //    }
 
     public int createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
+        //Inserting into the database returns the id of the just inserted row
         return ((int)database.createAlarm(message, recipientPhoneNumber, alarmTime, alarmIsOn));
     }
 
     public Alarm getAlarm(int id) {
         return database.getAlarm(id);
+    }
+
+    public void updateAlarm(int id, String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
+        database.updateAlarm(id, message, recipientPhoneNumber, alarmTime, alarmIsOn);
     }
 }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
@@ -2,7 +2,7 @@ package com.ruinyourlifealarm.ruinyourlifealarm.business;
 
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Alarm;
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.DatabaseHandler;
-//import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Message;
+import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Message;
 
 import java.util.Calendar;
 
@@ -26,7 +26,7 @@ public class AccessAlarms {
 //        createAlarm(msgId, recipientPhoneNumber, alarmTime);
 //    }
 
-    public void createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime) {
+    public void createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
         //TODO
     }
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessAlarms.java
@@ -12,9 +12,11 @@ import java.util.Calendar;
 
 public class AccessAlarms {
     private DatabaseHandler database;
+    private AccessMessages accessMessages;
 
     public AccessAlarms(DatabaseHandler database) {
         this.database = database;
+        this.accessMessages = new AccessMessages(database);
     }
 
 //    public void createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
@@ -22,7 +24,7 @@ public class AccessAlarms {
 //    }
 //
 //    public void createAlarm(String customMessage, String recipientPhoneNumber, Time alarmTime) {
-//        int messageId = (int)(database.createMessage(customMessage));
+//        int messageId = accessMessages.createCustomMessage(customMessage);
 //        createAlarm(messageId, recipientPhoneNumber, alarmTime);
 //    }
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessMessages.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/business/AccessMessages.java
@@ -16,11 +16,15 @@ public class AccessMessages {
         this.database = database;
     }
 
-    public void createCustomMessage(String messageName) {
-        database.createMessage(messageName);
+    public int createCustomMessage(String messageName) {
+        return database.createMessage(messageName);
     }
 
     public List<Message> getAllMessages() {
         return database.getAllMessages();
+    }
+
+    public Message getMessage(int id) {
+        return database.getMessage(id);
     }
 }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
@@ -1,6 +1,6 @@
 package com.ruinyourlifealarm.ruinyourlifealarm.persistence;
 
-import java.sql.Time;
+import java.util.Calendar;
 
 /**
  * Created by tiffanyjiang on 2017-12-02.
@@ -8,9 +8,16 @@ import java.sql.Time;
 
 public class Alarm {
     private int id;
-    private Message message;
+    private String message;
     private String recipientPhoneNumber;
-    private Time alarmTime;
+    private Calendar alarmTime;
+
+    public Alarm(int id, String message, String recipientPhoneNumber, Calendar alarmTime) {
+        this.id = id;
+        this.message = message;
+        this.recipientPhoneNumber = recipientPhoneNumber;
+        this.alarmTime = alarmTime;
+    }
 
     public int getId() {
         return id;
@@ -20,11 +27,11 @@ public class Alarm {
         this.id = id;
     }
 
-    public Message getMessage() {
+    public String getMessage() {
         return message;
     }
 
-    public void setMessage(Message message) {
+    public void setMessage(String message) {
         this.message = message;
     }
 
@@ -36,19 +43,51 @@ public class Alarm {
         this.recipientPhoneNumber = recipientPhoneNumber;
     }
 
-    public Time getAlarmTime() {
+    public Calendar getAlarmTime() {
         return alarmTime;
     }
 
-    public void setAlarmTime(Time alarmTime) {
+    public void setAlarmTime(Calendar alarmTime) {
         this.alarmTime = alarmTime;
     }
 
-    public Alarm(int id, Message message, String recipientPhoneNumber, Time alarmTime) {
-
-        this.id = id;
-        this.message = message;
-        this.recipientPhoneNumber = recipientPhoneNumber;
-        this.alarmTime = alarmTime;
-    }
+//    public int getId() {
+//        return id;
+//    }
+//
+//    public void setId(int id) {
+//        this.id = id;
+//    }
+//
+//    public Message getMessage() {
+//        return message;
+//    }
+//
+//    public void setMessage(Message message) {
+//        this.message = message;
+//    }
+//
+//    public String getRecipientPhoneNumber() {
+//        return recipientPhoneNumber;
+//    }
+//
+//    public void setRecipientPhoneNumber(String recipientPhoneNumber) {
+//        this.recipientPhoneNumber = recipientPhoneNumber;
+//    }
+//
+//    public Time getAlarmTime() {
+//        return alarmTime;
+//    }
+//
+//    public void setAlarmTime(Time alarmTime) {
+//        this.alarmTime = alarmTime;
+//    }
+//
+//    public Alarm(int id, Message message, String recipientPhoneNumber, Time alarmTime) {
+//
+//        this.id = id;
+//        this.message = message;
+//        this.recipientPhoneNumber = recipientPhoneNumber;
+//        this.alarmTime = alarmTime;
+//    }
 }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
@@ -11,12 +11,14 @@ public class Alarm {
     private String message;
     private String recipientPhoneNumber;
     private Calendar alarmTime;
+    private boolean alarmIsOn;
 
-    public Alarm(int id, String message, String recipientPhoneNumber, Calendar alarmTime) {
+    public Alarm(int id, String message, String recipientPhoneNumber, Calendar alarmTime, boolean alarmIsOn) {
         this.id = id;
         this.message = message;
         this.recipientPhoneNumber = recipientPhoneNumber;
         this.alarmTime = alarmTime;
+        this.alarmIsOn = alarmIsOn;
     }
 
     public int getId() {
@@ -51,6 +53,13 @@ public class Alarm {
         this.alarmTime = alarmTime;
     }
 
+    public boolean isAlarmIsOn() {
+        return alarmIsOn;
+    }
+
+    public void setAlarmIsOn(boolean alarmIsOn) {
+        this.alarmIsOn = alarmIsOn;
+    }
 //    public int getId() {
 //        return id;
 //    }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/Alarm.java
@@ -53,7 +53,7 @@ public class Alarm {
         this.alarmTime = alarmTime;
     }
 
-    public boolean isAlarmIsOn() {
+    public boolean getAlarmIsOn() {
         return alarmIsOn;
     }
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
@@ -146,14 +146,26 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         }
 
         long id = db.insert(TABLE_ALARMS, null, values);
-        Log.d("", ""+id);
         db.close();
 
         return id;
     }
 
-    public void updateAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, Boolean alarmIsOn) {
+    public void updateAlarm(int id, String message, String recipientPhoneNumber, Calendar alarmTime, Boolean alarmIsOn) {
+        SQLiteDatabase db = this.getWritableDatabase();
 
+        ContentValues values = new ContentValues();
+        values.put(KEY_ALARMS_MESSAGE_ID, message);
+        values.put(KEY_ALARMS_RECIPIENT_PHONE_NUMBER, recipientPhoneNumber);
+        values.put(KEY_ALARMS_ALARM_TIME, convertCalendarToString(alarmTime));
+
+        if (alarmIsOn) {
+            values.put(KEY_ALARMS_ALARM_IS_ON, 1);
+        } else {
+            values.put(KEY_ALARMS_ALARM_IS_ON, 0);
+        }
+
+        db.update(TABLE_ALARMS, values, KEY_ALARMS_ID + " = ?", new String[] { String.valueOf(id) });
     }
 
     public Alarm getAlarm(int id) {

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
@@ -5,10 +5,13 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.util.Log;
 
 import java.sql.Time;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by tiffanyjiang on 2017-12-02.
@@ -26,9 +29,11 @@ public class DatabaseHandler extends SQLiteOpenHelper {
     //Alarms table table/column names
     private static final String TABLE_ALARMS = "ALARMS";
     private static final String KEY_ALARMS_ID = "ID";
-    private static final String KEY_ALARMS_MESSAGE_ID = "MESSAGE_ID";
+//    private static final String KEY_ALARMS_MESSAGE_ID = "MESSAGE_ID";
+    private static final String KEY_ALARMS_MESSAGE_ID = "MESSAGE";
     private static final String KEY_ALARMS_RECIPIENT_PHONE_NUMBER = "RECIPIENT_PHONE_NUMBER";
     private static final String KEY_ALARMS_ALARM_TIME = "ALARM_TIME";
+    private static final String KEY_ALARMS_ALARM_IS_ON = "ALARM_IS_ON";
 
     public DatabaseHandler (Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
@@ -37,7 +42,8 @@ public class DatabaseHandler extends SQLiteOpenHelper {
     @Override
     public void onCreate(SQLiteDatabase db) {
         String CREATE_MESSAGES_TABLE = "CREATE TABLE " + TABLE_MESSAGES + " (" + KEY_MESSAGES_ID + " INTEGER PRIMARY KEY, " + KEY_MESSAGES_NAME + " TEXT)";
-        String CREATE_ALARMS_TABLE = "CREATE TABLE " + TABLE_ALARMS + " (" + KEY_ALARMS_ID + " INTEGER PRIMARY KEY, " + KEY_ALARMS_ALARM_TIME + " TIME, " + KEY_ALARMS_MESSAGE_ID + " INTEGER, " + KEY_ALARMS_RECIPIENT_PHONE_NUMBER + " TEXT, " + "CONSTRAINT FK_" + TABLE_ALARMS + "_" + TABLE_MESSAGES + " FOREIGN KEY(" + KEY_ALARMS_MESSAGE_ID + ") REFERENCES " + TABLE_MESSAGES + "(" + KEY_MESSAGES_ID + "))";
+//        String CREATE_ALARMS_TABLE = "CREATE TABLE " + TABLE_ALARMS + " (" + KEY_ALARMS_ID + " INTEGER PRIMARY KEY, " + KEY_ALARMS_ALARM_TIME + " TIME, " + KEY_ALARMS_MESSAGE_ID + " INTEGER, " + KEY_ALARMS_RECIPIENT_PHONE_NUMBER + " TEXT, " + "CONSTRAINT FK_" + TABLE_ALARMS + "_" + TABLE_MESSAGES + " FOREIGN KEY(" + KEY_ALARMS_MESSAGE_ID + ") REFERENCES " + TABLE_MESSAGES + "(" + KEY_MESSAGES_ID + "))";
+        String CREATE_ALARMS_TABLE = "CREATE TABLE ALARMS (ID INTEGER PRIMARY KEY, MESSAGE TEXT, RECIPIENT_PHONE_NUMBER TEXT, ALARM_TIME TEXT, ALARM_IS_ON INTEGER)";
 
         db.execSQL(CREATE_MESSAGES_TABLE);
         db.execSQL(CREATE_ALARMS_TABLE);
@@ -108,24 +114,73 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         return messageList;
     }
 
+
     //Alarms
 
-    public long createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
+//    public long createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
+//        SQLiteDatabase db = this.getWritableDatabase();
+//
+//        ContentValues values = new ContentValues();
+//        values.put(KEY_ALARMS_MESSAGE_ID, messageId);
+//        values.put(KEY_ALARMS_RECIPIENT_PHONE_NUMBER, recipientPhoneNumber);
+//        values.put(KEY_ALARMS_ALARM_TIME, alarmTime.toString());
+//
+//        long id = db.insert(TABLE_ALARMS, null, values);
+//        db.close();
+//
+//        return id;
+//    }
+
+    public long createAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, Boolean alarmIsOn) {
         SQLiteDatabase db = this.getWritableDatabase();
 
         ContentValues values = new ContentValues();
-        values.put(KEY_ALARMS_MESSAGE_ID, messageId);
+        values.put(KEY_ALARMS_MESSAGE_ID, message);
         values.put(KEY_ALARMS_RECIPIENT_PHONE_NUMBER, recipientPhoneNumber);
-        values.put(KEY_ALARMS_ALARM_TIME, alarmTime.toString());
+        values.put(KEY_ALARMS_ALARM_TIME, convertCalendarToString(alarmTime));
 
-        long id = db.insert(TABLE_MESSAGES, null, values);
+        if (alarmIsOn) {
+            values.put(KEY_ALARMS_ALARM_IS_ON, 1);
+        } else {
+            values.put(KEY_ALARMS_ALARM_IS_ON, 0);
+        }
+
+        long id = db.insert(TABLE_ALARMS, null, values);
+        Log.d("", ""+id);
         db.close();
 
         return id;
     }
 
-    public void getAlarm(int id) {
+    public void updateAlarm(String message, String recipientPhoneNumber, Calendar alarmTime, Boolean alarmIsOn) {
 
+    }
+
+    public Alarm getAlarm(int id) {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(TABLE_ALARMS, new String[] { KEY_ALARMS_ID,
+                        KEY_ALARMS_MESSAGE_ID, KEY_ALARMS_RECIPIENT_PHONE_NUMBER, KEY_ALARMS_ALARM_TIME, KEY_ALARMS_ALARM_IS_ON }, KEY_ALARMS_ID + "=?",
+                new String[] { String.valueOf(id) }, null, null, null, null);
+        if (cursor != null)
+            cursor.moveToFirst();
+
+        Calendar c = convertStringToCalendar(cursor.getString(3));
+        boolean bool = Integer.parseInt(cursor.getString(4)) == 1;
+        Alarm alarm = new Alarm(Integer.parseInt(cursor.getString(0)), cursor.getString(1), cursor.getString(2), c, bool);
+
+        return alarm;
+    }
+
+    private String convertCalendarToString(Calendar c) {
+        return c.getTimeInMillis()+"";
+    }
+
+    private Calendar convertStringToCalendar(String s) {
+        Calendar c = Calendar.getInstance();
+        c.setTimeInMillis(Long.parseLong(s));
+
+        return c;
     }
 
     //TODO once we have >1 alarm

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
@@ -5,13 +5,10 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.util.Log;
 
-import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by tiffanyjiang on 2017-12-02.
@@ -68,7 +65,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
 
     //Messages
 
-    public long createMessage(String msg) {
+    public int createMessage(String msg) {
         SQLiteDatabase db = this.getWritableDatabase();
 
         ContentValues values = new ContentValues();
@@ -77,7 +74,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         long id = db.insert(TABLE_MESSAGES, null, values);
         db.close();
 
-        return id;
+        return (int)id;
     }
 
     public Message getMessage(int id) {

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/persistence/DatabaseHandler.java
@@ -60,14 +60,33 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         onCreate(db);
     }
 
-    public void createMessage(String msg) {
+    //Messages
+
+    public long createMessage(String msg) {
         SQLiteDatabase db = this.getWritableDatabase();
 
         ContentValues values = new ContentValues();
         values.put(KEY_MESSAGES_NAME, msg);
 
-        db.insert(TABLE_MESSAGES, null, values);
+        long id = db.insert(TABLE_MESSAGES, null, values);
         db.close();
+
+        return id;
+    }
+
+    public Message getMessage(int id) {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(TABLE_MESSAGES, new String[] { KEY_MESSAGES_ID,
+                        KEY_MESSAGES_NAME }, KEY_MESSAGES_ID + "=?",
+                new String[] { String.valueOf(id) }, null, null, null, null);
+        if (cursor != null)
+            cursor.moveToFirst();
+
+        Message msg = new Message(Integer.parseInt(cursor.getString(0)),
+                cursor.getString(1));
+
+        return msg;
     }
 
     public List<Message> getAllMessages() {
@@ -87,5 +106,30 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         }
 
         return messageList;
+    }
+
+    //Alarms
+
+    public long createAlarm(int messageId, String recipientPhoneNumber, Time alarmTime) {
+        SQLiteDatabase db = this.getWritableDatabase();
+
+        ContentValues values = new ContentValues();
+        values.put(KEY_ALARMS_MESSAGE_ID, messageId);
+        values.put(KEY_ALARMS_RECIPIENT_PHONE_NUMBER, recipientPhoneNumber);
+        values.put(KEY_ALARMS_ALARM_TIME, alarmTime.toString());
+
+        long id = db.insert(TABLE_MESSAGES, null, values);
+        db.close();
+
+        return id;
+    }
+
+    public void getAlarm(int id) {
+
+    }
+
+    //TODO once we have >1 alarm
+    public List<Alarm> getAllAlarms() {
+        return null;
     }
 }

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
@@ -88,7 +88,19 @@ public class MainActivity extends AppCompatActivity {
         Log.d("blah3", ""+a.getAlarmTime().get(Calendar.DATE));
         Log.d("blah3", ""+a.getAlarmTime().get(Calendar.HOUR));
         Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MINUTE));
+        Log.d("blah4", a.getAlarmIsOn()+"");
 
+        c.set(2017, 12, 6, 2, 56);
+        aa.updateAlarm(id, "test message UPDATED", "1234567", c, false);
+
+        a = aa.getAlarm(id);
+        Log.d("blah", a.getMessage());
+        Log.d("blah2", a.getRecipientPhoneNumber());
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.YEAR));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MONTH));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.DATE));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.HOUR));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MINUTE));
         Log.d("blah4", a.getAlarmIsOn()+"");
     }
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
@@ -5,7 +5,6 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -13,7 +12,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.telephony.SmsManager;
 import java.util.ArrayList;
-import java.util.Calendar;
 
 import android.support.v4.app.ActivityCompat;
 
@@ -21,9 +19,6 @@ import com.ruinyourlifealarm.ruinyourlifealarm.Main;
 import com.ruinyourlifealarm.ruinyourlifealarm.R;
 import android.content.Intent;
 
-import com.ruinyourlifealarm.ruinyourlifealarm.business.AccessAlarms;
-import com.ruinyourlifealarm.ruinyourlifealarm.business.AccessMessages;
-import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Alarm;
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.DatabaseHandler;
 
 public class MainActivity extends AppCompatActivity {

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
@@ -5,6 +5,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -12,12 +13,17 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.telephony.SmsManager;
 import java.util.ArrayList;
+import java.util.Calendar;
+
 import android.support.v4.app.ActivityCompat;
 
 import com.ruinyourlifealarm.ruinyourlifealarm.Main;
 import com.ruinyourlifealarm.ruinyourlifealarm.R;
 import android.content.Intent;
 
+import com.ruinyourlifealarm.ruinyourlifealarm.business.AccessAlarms;
+import com.ruinyourlifealarm.ruinyourlifealarm.business.AccessMessages;
+import com.ruinyourlifealarm.ruinyourlifealarm.persistence.Alarm;
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.DatabaseHandler;
 
 public class MainActivity extends AppCompatActivity {
@@ -66,6 +72,24 @@ public class MainActivity extends AppCompatActivity {
 
         DatabaseHandler db = new DatabaseHandler(this);
         Main.setDatabase(db);
+
+
+        AccessAlarms aa = new AccessAlarms(Main.getDatabase());
+        Calendar c = Calendar.getInstance();
+        c.set(2017, 11, 3, 11, 30);
+        int id = aa.createAlarm("test message", "12345", c, true);
+
+        Alarm a = aa.getAlarm(id);
+        Log.d("blah", a.getMessage());
+        Log.d("blah2", a.getRecipientPhoneNumber());
+//        Log.d("blah3", a.getAlarmTime().toString());
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.YEAR));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MONTH));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.DATE));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.HOUR));
+        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MINUTE));
+
+        Log.d("blah4", a.getAlarmIsOn()+"");
     }
 
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
@@ -72,36 +72,6 @@ public class MainActivity extends AppCompatActivity {
 
         DatabaseHandler db = new DatabaseHandler(this);
         Main.setDatabase(db);
-
-
-        AccessAlarms aa = new AccessAlarms(Main.getDatabase());
-        Calendar c = Calendar.getInstance();
-        c.set(2017, 11, 3, 11, 30);
-        int id = aa.createAlarm("test message", "12345", c, true);
-
-        Alarm a = aa.getAlarm(id);
-        Log.d("blah", a.getMessage());
-        Log.d("blah2", a.getRecipientPhoneNumber());
-//        Log.d("blah3", a.getAlarmTime().toString());
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.YEAR));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MONTH));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.DATE));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.HOUR));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MINUTE));
-        Log.d("blah4", a.getAlarmIsOn()+"");
-
-        c.set(2017, 12, 6, 2, 56);
-        aa.updateAlarm(id, "test message UPDATED", "1234567", c, false);
-
-        a = aa.getAlarm(id);
-        Log.d("blah", a.getMessage());
-        Log.d("blah2", a.getRecipientPhoneNumber());
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.YEAR));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MONTH));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.DATE));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.HOUR));
-        Log.d("blah3", ""+a.getAlarmTime().get(Calendar.MINUTE));
-        Log.d("blah4", a.getAlarmIsOn()+"");
     }
 
 

--- a/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
+++ b/app/src/main/java/com/ruinyourlifealarm/ruinyourlifealarm/presentation/MainActivity.java
@@ -16,7 +16,6 @@ import android.support.v4.app.ActivityCompat;
 
 import com.ruinyourlifealarm.ruinyourlifealarm.Main;
 import com.ruinyourlifealarm.ruinyourlifealarm.R;
-import com.ruinyourlifealarm.ruinyourlifealarm.presentation.NewAlarmActivity;
 import android.content.Intent;
 
 import com.ruinyourlifealarm.ruinyourlifealarm.persistence.DatabaseHandler;


### PR DESCRIPTION
Commented out any conflicting `Message`-related functionality as message is now temporarily stored as a string in `Alarm`

Example usage:
```
        AccessAlarms aa = new AccessAlarms(Main.getDatabase());
        Calendar c = Calendar.getInstance();
        c.set(2017, 11, 3, 11, 30);
        int id = aa.createAlarm("test message", "12345", c, true);

        Alarm a = aa.getAlarm(id);
        Log.d("blah", a.getMessage());
        Log.d("blah", a.getRecipientPhoneNumber());
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.YEAR));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.MONTH));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.DATE));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.HOUR));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.MINUTE));
        Log.d("blah", ""+a.getAlarmIsOn());

        c.set(2017, 12, 6, 2, 56);
        aa.updateAlarm(id, "test message UPDATED", "1234567", c, false);

        a = aa.getAlarm(id);
        Log.d("blah", a.getMessage());
        Log.d("blah", a.getRecipientPhoneNumber());
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.YEAR));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.MONTH));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.DATE));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.HOUR));
        Log.d("blah", ""+a.getAlarmTime().get(Calendar.MINUTE));
        Log.d("blah", ""+a.getAlarmIsOn());
```